### PR TITLE
Timeline save errors fixed

### DIFF
--- a/src/components/TimelineWrapper.js
+++ b/src/components/TimelineWrapper.js
@@ -81,13 +81,13 @@ class TimelineWrapper extends React.Component {
 
   updateEvent(name, idx, color, description, imgUrl, vidUrl, radius, height) {
     var dates = this.props.data.dates;
-    dates[idx].name = name;
-    dates[idx].color = color;
+    dates[idx].name = name || "";
+    dates[idx].color = color || null;
     dates[idx].description = description;
-    dates[idx].imgUrl = imgUrl;
-    dates[idx].vidUrl = vidUrl;
-    dates[idx].radius = radius;
-    dates[idx].height = height;
+    dates[idx].imgUrl = imgUrl || "";
+    dates[idx].vidUrl = vidUrl || "";
+    dates[idx].radius = radius || 5;
+    dates[idx].height = height || 200;
     // this.setState({ dates });
     this.props.dispatchUpdateEvents(dates);
   }

--- a/src/store/timeline.js
+++ b/src/store/timeline.js
@@ -73,7 +73,17 @@ const empty = {
     start: '2015, 1, 1',
     end: '2018, 1, 1',
     radius: 10,
-    dates: []
+    dates: [{
+      id: 3,
+      name: '',
+      date: '',
+      color: null,
+      radius: 0,
+      height: 0,
+      description: '',
+      imgUrl: '',
+      vidUrl: ''
+    }]
   }
 };
 


### PR DESCRIPTION
Timeline now saves with empty strings if user does not input data. Before, it was putting in undefined and causing an error on save.